### PR TITLE
feat: add proper changeset attributes and add some tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
+      "!src/helpers/storage.js",
       "!<rootDir>/node_modules/"
     ],
     "coverageReporters": [

--- a/src/components/edition/OsmoseSidebar.jsx
+++ b/src/components/edition/OsmoseSidebar.jsx
@@ -4,6 +4,7 @@ import { WhiteTheme, Sidebar, Osmose } from 'osm-ui-react';
 
 import EditorModal from './EditorModal';
 import { osmose, osm } from 'helpers/requests';
+import { buildChangesetCreatedBy, buildChangesetComment } from 'helpers/osm';
 
 class OsmoseSidebar extends React.Component {
   state = {
@@ -30,8 +31,8 @@ class OsmoseSidebar extends React.Component {
     const elemId = `${original.type}/${original.id}`;
 
     const changesetIdP = osm.request.createChangeset(
-      'romain',
-      'This is a test 1'
+      buildChangesetCreatedBy(),
+      buildChangesetComment(this.props.themePath)
     );
     const elemP = osm.request.fetchElement(elemId);
 

--- a/src/const/osm.js
+++ b/src/const/osm.js
@@ -1,0 +1,3 @@
+export const CHANGESET_CREATED_BY = 'MapContrib {version}';
+export const CHANGESET_COMMENT =
+  'Contribution sent from the following MapContrib theme: {url}';

--- a/src/helpers/__mocks__/storage.js
+++ b/src/helpers/__mocks__/storage.js
@@ -1,0 +1,7 @@
+export const getProjectVersion = jest.fn().mockImplementation(() => '1.2.3');
+export const getOsmAuthToken = jest
+  .fn()
+  .mockImplementation(name => `Value of the ${name} token`);
+export const getInstanceUrl = jest
+  .fn()
+  .mockImplementation(() => 'https://www.mapcontrib.xyz');

--- a/src/helpers/__tests__/osm.test.js
+++ b/src/helpers/__tests__/osm.test.js
@@ -1,0 +1,54 @@
+import {
+  buildChangesetComment,
+  buildChangesetCreatedBy,
+  computeId,
+  cleanOsmAuthToken,
+  getTokensFromLocalStorage
+} from 'helpers/osm';
+
+jest.mock('helpers/storage');
+
+describe('OSM helpers', () => {
+  it('Should build a changeset comment', () => {
+    // Based on the mocks
+    const instanceUrl = 'https://www.mapcontrib.xyz';
+    const themePath = '/a_theme_url';
+    const fullUrl = `${instanceUrl}${themePath}`;
+    const result = buildChangesetComment(themePath);
+    const expected = `Contribution sent from the following MapContrib theme: ${fullUrl}`;
+    expect(result).toBe(expected);
+  });
+
+  it('Should build a changeset "created by"', () => {
+    const result = buildChangesetCreatedBy();
+    // Based on the mocks
+    const expected = 'MapContrib 1.2.3';
+    expect(result).toBe(expected);
+  });
+
+  it('Should build a full OSM ID', () => {
+    const result = computeId('node', '4567');
+    const expected = 'node/4567';
+    expect(result).toBe(expected);
+  });
+
+  it('Should clean an osm-auth token', () => {
+    const result = cleanOsmAuthToken('aze"aze\\aze');
+    const expected = 'azeazeaze';
+    expect(result).toBe(expected);
+  });
+
+  it('Should clean an osm-auth token', () => {
+    const result = getTokensFromLocalStorage();
+    const expected = {
+      apiToken:
+        'Value of the https://api.openstreetmap.org/api/0.6oauth_token token',
+      apiTokenSecret:
+        'Value of the https://api.openstreetmap.org/api/0.6oauth_token_secret token',
+      osmToken: 'Value of the https://www.openstreetmap.orgoauth_token token',
+      osmTokenSecret:
+        'Value of the https://www.openstreetmap.orgoauth_token_secret token'
+    };
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/helpers/osm.js
+++ b/src/helpers/osm.js
@@ -1,15 +1,38 @@
-export const computeId = (type, id) => `${type}/${id}`;
+import { CHANGESET_CREATED_BY, CHANGESET_COMMENT } from 'const/osm';
+import {
+  getProjectVersion,
+  getOsmAuthToken,
+  getInstanceUrl
+} from 'helpers/storage';
 
-const cleanToken = token => token && token.replace(/"|\\/gi, '');
+export function computeId(type, id) {
+  return `${type}/${id}`;
+}
 
-export const getTokensFromLocalStorage = () => ({
-  apiToken: cleanToken(
-    localStorage['https://api.openstreetmap.org/api/0.6oauth_token']
-  ),
-  apiTokenSecret: cleanToken(
-    localStorage['https://api.openstreetmap.org/api/0.6oauth_token_secret']
-  ),
-  osmToken: localStorage['https://www.openstreetmap.orgoauth_token'],
-  osmTokenSecret:
-    localStorage['https://www.openstreetmap.orgoauth_token_secret']
-});
+export function cleanOsmAuthToken(token) {
+  return (token || '').replace(/"|\\/gi, '');
+}
+
+export function getTokensFromLocalStorage() {
+  return {
+    apiToken: cleanOsmAuthToken(
+      getOsmAuthToken('https://api.openstreetmap.org/api/0.6oauth_token')
+    ),
+    apiTokenSecret: cleanOsmAuthToken(
+      getOsmAuthToken('https://api.openstreetmap.org/api/0.6oauth_token_secret')
+    ),
+    osmToken: getOsmAuthToken('https://www.openstreetmap.orgoauth_token'),
+    osmTokenSecret: getOsmAuthToken(
+      'https://www.openstreetmap.orgoauth_token_secret'
+    )
+  };
+}
+
+export function buildChangesetCreatedBy() {
+  return CHANGESET_CREATED_BY.replace('{version}', getProjectVersion());
+}
+
+export function buildChangesetComment(themePath) {
+  const url = `${getInstanceUrl()}${themePath}`;
+  return CHANGESET_COMMENT.replace('{url}', url);
+}

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,0 +1,13 @@
+import { version } from '../../package.json';
+
+export function getProjectVersion() {
+  return version;
+}
+
+export function getOsmAuthToken(name) {
+  return localStorage.getItem(name);
+}
+
+export function getInstanceUrl() {
+  return window.location.href.replace(/^(\w+:\/\/[\w.:]+).*$/i, '$1');
+}


### PR DESCRIPTION
Fill the changeset attributes with the same data from MapContrib v1 (project's version, theme URL).

Also, it adds some tests to fully cover `helpers/osm`.

@iOiurson, I replaced the arrow functions with "real" functions to properly display/read the code coverage. It was not clear for the one line functions. Is it ok for you?